### PR TITLE
Add optional decoding

### DIFF
--- a/Sources/Decodable/Decoder.swift
+++ b/Sources/Decodable/Decoder.swift
@@ -72,14 +72,36 @@ public struct Decoder {
         return value
     }
 
-    /// Decode `Value` located at `key`, throws Error but will return nil if key is missing.
-    public func decodeOptional<Value>(key: String) throws -> Value? {
+    func ignoreMissingKey<Value>(@autoclosure expression: () throws -> Value) throws -> Value? {
         do {
-            return try decode(key)
+            return try expression()
         } catch Error.MissingKey {
             return nil
         } catch {
             throw error
         }
+    }
+
+    /// Decode an `NSURL` located at `key`, throws Error including Error.InvalidURL but will return
+    /// nil if key is missing.
+    public func decodeOptional(key: String) throws -> NSURL? {
+        return try ignoreMissingKey(try decode(key))
+    }
+
+    /// Decode an `NSDate` located at `key`, throws Error including Error.InvalidDate but will return
+    /// nil if key is missing.
+    public func decodeOptional(key: String, formatter: NSDateFormatter) throws -> NSDate? {
+        return try ignoreMissingKey(try decode(key))
+    }
+
+    /// Decode a `Decodable` `Value` located at `key`, throws Error but will return nil if key is
+    /// missing.
+    public func decodeOptional<Value: Decodable>(key: String) throws -> Value? {
+        return try ignoreMissingKey(try decode(key))
+    }
+
+    /// Decode `Value` located at `key`, throws Error but will return nil if key is missing.
+    public func decodeOptional<Value>(key: String) throws -> Value? {
+        return try ignoreMissingKey(try decode(key))
     }
 }

--- a/Sources/Decodable/Decoder.swift
+++ b/Sources/Decodable/Decoder.swift
@@ -71,4 +71,15 @@ public struct Decoder {
 
         return value
     }
+
+    /// Decode `Value` located at `key`, throws Error but will return nil if key is missing.
+    public func decodeOptional<Value>(key: String) throws -> Value? {
+        do {
+            return try decode(key)
+        } catch Error.MissingKey {
+            return nil
+        } catch {
+            throw error
+        }
+    }
 }

--- a/Tests/Decodable/DecodableTests.swift
+++ b/Tests/Decodable/DecodableTests.swift
@@ -17,4 +17,19 @@ class DecodableTests: XCTestCase {
         XCTAssertEqual(person.age, 25)
         XCTAssertEqual(person.email, "johndoe@gmail.com")
     }
+
+    func testDecodesPersonMissingEmail() throws {
+        let person = try Person(json: [
+            "name": [
+                "first": "John",
+                "second": "Doe"
+            ],
+            "age": 25,
+        ])
+
+        XCTAssertEqual(person.name.first, "John")
+        XCTAssertEqual(person.name.second, "Doe")
+        XCTAssertEqual(person.age, 25)
+        XCTAssertNil(person.email)
+    }
 }

--- a/Tests/Decodable/DecoderTests.swift
+++ b/Tests/Decodable/DecoderTests.swift
@@ -130,4 +130,31 @@ class DecoderTests: XCTestCase {
             }
         }
     }
+
+    func testDecodingOptionalString() throws {
+        let decoder = Decoder(json: ["string": "Decoded"])
+        let result: String? = try decoder.decodeOptional("string")
+        XCTAssertEqual(result, "Decoded")
+    }
+
+    func testDecodingOptionalMissingKey() throws {
+        let decoder = Decoder(json: [:])
+        let result: String? = try decoder.decodeOptional("string")
+        XCTAssertNil(result)
+    }
+
+    func testDecodingOptionalWrongType() {
+        let decoder = Decoder(json: ["string": "Decoded"])
+        XCTAssertThrowsError(try decoder.decode("string") as Int) { error in
+            switch error {
+            case let Decoder.Error.WrongType(key, _, _):
+                XCTAssertEqual(key, "string")
+                // FIXME: Properly test types returned.
+//                XCTAssertEqual(String(expected), String(Int.self))
+//                XCTAssertEqual(String(actual), String(String.self))
+            default:
+                XCTFail("Wrong error thrown")
+            }
+        }
+    }
 }

--- a/Tests/Decodable/Person.swift
+++ b/Tests/Decodable/Person.swift
@@ -8,7 +8,7 @@ struct Person: Decodable {
     init(decoder: Decoder) throws {
         self.name = try decoder.decode("name")
         self.age = try decoder.decode("age")
-        self.email = try decoder.decode("email")
+        self.email = try decoder.decodeOptional("email")
     }
 
     struct Name: Decodable {


### PR DESCRIPTION
Wrap existing decoding methods in `do { } catch { }` in order to ignore missing key errors and just return `nil`.
